### PR TITLE
Scale9grid fix

### DIFF
--- a/scripts/format/swf/instance/MovieClip.hx
+++ b/scripts/format/swf/instance/MovieClip.hx
@@ -610,7 +610,6 @@ class MovieClip extends flash.display.MovieClip
 	{
 		graphics.clear();
 
-		var matrix = new Matrix();
 		var cols = [0, scale9Rect.left, scale9Rect.right, bitmap.width];
 		var rows = [0, scale9Rect.top, scale9Rect.bottom, bitmap.height];
 		var outerWidth = bitmap.width - (cols[2] - cols[1]);
@@ -633,23 +632,23 @@ class MovieClip extends flash.display.MovieClip
 				h = rows[row + 1] - rows[row];
 
 				// this makes sure the bitmap is drawn in the right spot to be drawn
+				var matrix = new Matrix();
 				matrix.identity();
-				matrix.translate(dx - sourceX, dy - sourceY);
-
-				// scale the middle section
+				var applied_scaleY = 1;
+				var applied_scaleX = 1;
 				if (row == 1)
 				{
-					h *= innerScaleY;
-					matrix.scale(1, innerScaleY);
-					matrix.translate(0, dy - sourceY * innerScaleY);
+					applied_scaleY = innerScaleY;
 				}
-
 				if (col == 1)
 				{
-					w *= innerScaleX;
-					matrix.scale(innerScaleX, 1);
-					matrix.translate(dx - sourceX * innerScaleX, 0);
+					applied_scaleX = innerScaleX;
 				}
+
+				h *= applied_scaleY;
+				w *= applied_scaleX;
+				matrix.translate((dx - sourceX) * applied_scaleX, (dy - sourceY) * applied_scaleY);
+				matrix.scale(applied_scaleX, applied_scaleY);
 
 				// now draw it
 				graphics.beginBitmapFill(bitmap, matrix, false, true);

--- a/src/openfl/_internal/renderer/context3D/Context3DShape.hx
+++ b/src/openfl/_internal/renderer/context3D/Context3DShape.hx
@@ -51,10 +51,10 @@ class Context3DShape
 
 				// TODO: scale9Grid
 
-				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context /*, scale9Grid, shape*/);
+				var vertexBuffer = graphics.__bitmap.getVertexBuffer(context, scale9Grid, shape);
 				if (shader.__position != null) context.setVertexBufferAt(shader.__position.index, vertexBuffer, 0, FLOAT_3);
 				if (shader.__textureCoord != null) context.setVertexBufferAt(shader.__textureCoord.index, vertexBuffer, 3, FLOAT_2);
-				var indexBuffer = graphics.__bitmap.getIndexBuffer(context /*, scale9Grid*/);
+				var indexBuffer = graphics.__bitmap.getIndexBuffer(context, scale9Grid);
 				context.drawTriangles(indexBuffer);
 
 				#if gl_stats

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1656,13 +1656,13 @@ class BitmapData implements IBitmapDrawable
 
 					var left = scale9Grid.x;
 					var top = scale9Grid.y;
-					var right = width - centerX - left;
-					var bottom = height - centerY - top;
+					var right = __vertexBufferWidth - centerX - left;
+					var bottom = __vertexBufferHeight - centerY - top;
 
-					var uvLeft = left / width;
-					var uvTop = top / height;
-					var uvCenterX = centerX / width;
-					var uvCenterY = centerY / height;
+					var uvLeft = left / __vertexBufferWidth;
+					var uvTop = top / __vertexBufferHeight;
+					var uvCenterX = scale9Grid.width / __vertexBufferWidth;
+					var uvCenterY = scale9Grid.height / __vertexBufferHeight;
 					var uvRight = right / width;
 					var uvBottom = bottom / height;
 
@@ -1670,8 +1670,8 @@ class BitmapData implements IBitmapDrawable
 					var renderedTop = top / targetObject.scaleY;
 					var renderedRight = right / targetObject.scaleX;
 					var renderedBottom = bottom / targetObject.scaleY;
-					var renderedCenterX = (targetObject.width / targetObject.scaleX) - renderedLeft - renderedRight;
-					var renderedCenterY = (targetObject.height / targetObject.scaleY) - renderedTop - renderedBottom;
+					var renderedCenterX = (width - renderedLeft - renderedRight);
+					var renderedCenterY = (height - renderedTop - renderedBottom);
 
 					// 3 ——— 2 ——— 5 ——— 7
 					// |  /  |  /  |  /  |


### PR DESCRIPTION
uV coordinates should not be scaled; vertex coordinates need to be scaled by the destination texture dimensions, not by the source texture dimensions.

(Also cleaned up the matrix scaling in MovieClip, specifically for the case of the middle box.)